### PR TITLE
Rubyfy the pagination methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ Attributes:
 Attributes
 - `per_page` (integer)
 - `current_page` (integer)
-- `is_first_page` (boolean)
-- `is_last_page` (boolean)
+- `first_page?` (boolean)
+- `last_page?` (boolean)
 
 ### `OmiseGO::List`
 

--- a/lib/omisego/pagination.rb
+++ b/lib/omisego/pagination.rb
@@ -1,6 +1,7 @@
 module OmiseGO
   class Pagination < Base
     attributes :per_page, :is_last_page, :is_first_page, :current_page
+    private :is_first_page, :is_last_page
 
     def first_page?
       is_first_page
@@ -8,16 +9,6 @@ module OmiseGO
 
     def last_page?
       is_last_page
-    end
-
-    private
-
-    def is_first_page
-      @is_first_page
-    end
-
-    def is_last_page
-      @is_last_page
     end
   end
 end

--- a/lib/omisego/pagination.rb
+++ b/lib/omisego/pagination.rb
@@ -1,5 +1,23 @@
 module OmiseGO
   class Pagination < Base
     attributes :per_page, :is_last_page, :is_first_page, :current_page
+
+    def first_page?
+      is_first_page
+    end
+
+    def last_page?
+      is_last_page
+    end
+
+    private
+
+    def is_first_page
+      @is_first_page
+    end
+
+    def is_last_page
+      @is_last_page
+    end
   end
 end


### PR DESCRIPTION
# Overview

The OmiseGO::Pagination currently includes two methods which do not feel very ruby-esc, `is_first/last_page`

The ruby style guide mentions both "offences", linked below.
https://github.com/bbatsov/ruby-style-guide\#bool-methods-qmark
https://github.com/bbatsov/ruby-style-guide\#bool-methods-prefix

# Changes

- `is_first_page` => `first_page?`
- `is_last_page` => `last_page?`

# Implementation Details

Override attr_reader and make `is_first/last_page` methods private
Define `first/last_page?` methods

# Usage

```ruby
response = OmiseGO::Transaction.all_for_user(provider_user_id: some_user.uuid)
response.pagination.first_page?
response.pagination.last_page?
```

# Impact

Not backwards compatible